### PR TITLE
WIP: Improve FIT file parsing with rust

### DIFF
--- a/native/rust_fit/Cargo.lock
+++ b/native/rust_fit/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +95,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo-types"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f47c611187777bbca61ea7aba780213f5f3441fd36294ab333e96cfa791b65"
+dependencies = [
+ "approx",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +156,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -177,6 +204,15 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "polyline"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f19cbf429afe5a5186d4c6ca7b246b446b2d18919eefdddb521792d57c874f67"
+dependencies = [
+ "geo-types",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -229,7 +265,10 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 name = "rust_fit"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "fitparser",
+ "geo-types",
+ "polyline",
  "rustler",
 ]
 

--- a/native/rust_fit/Cargo.toml
+++ b/native/rust_fit/Cargo.toml
@@ -12,4 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 fitparser = "0.7.0"
 rustler = "0.34.0"
+chrono = { version = "0.4", features = ["serde"] }
+polyline = "0.11"
+geo-types = "0.7"
 

--- a/native/rust_fit/src/lib.rs
+++ b/native/rust_fit/src/lib.rs
@@ -1,35 +1,223 @@
-use rustler::{Encoder, Env, Error, Term, NifStruct};
+use chrono::{DateTime, NaiveDateTime, Utc};
+use fitparser;
+use fitparser::profile::MesgNum;
+use polyline::encode_coordinates;
+use rustler::{Encoder, Env, Error, NifStruct, Term};
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
-use fitparser;
+use geo_types::LineString;
+
+#[derive(NifStruct)]
+#[module = "Squeeze.FitRecord.Coordinates"]
+struct Coordinates {
+    lat: f64,
+    lon: f64,
+}
+
+#[derive(NifStruct)]
+#[module = "Squeeze.FitRecord.Trackpoint"]
+struct Trackpoint {
+    altitude: Option<f64>,
+    cadence: Option<i32>,
+    coordinates: Option<Coordinates>,
+    distance: Option<f64>,
+    heartrate: Option<i32>,
+    velocity: Option<f64>,
+    moving: bool,
+    time: i64,
+}
+
+#[derive(NifStruct)]
+#[module = "Squeeze.FitRecord.Lap"]
+struct Lap {
+    average_cadence: Option<f64>,
+    average_speed: Option<f64>,
+    distance: Option<f64>,
+    elapsed_time: Option<i32>,
+    start_index: i32,
+    end_index: i32,
+    lap_index: i32,
+    max_speed: Option<f64>,
+    moving_time: Option<i32>,
+    name: Option<String>,
+    split: i32,
+    start_date: String,
+    start_date_local: String,
+    total_elevation_gain: Option<f64>,
+}
 
 #[derive(NifStruct)]
 #[module = "Squeeze.FitRecord"]
-struct FitRecord {
-    kind: String,
-    fields: Vec<(String, String)>,
+struct Activity {
+    r#type: String,
+    activity_type: String,
+    distance: Option<f64>,
+    duration: Option<i32>,
+    moving_time: Option<i32>,
+    elapsed_time: Option<i32>,
+    start_at: String,
+    start_at_local: String,
+    elevation_gain: Option<f64>,
+    polyline: String,
+    trackpoints: Vec<Trackpoint>,
+    laps: Vec<Lap>,
+}
+
+fn parse_timestamp(timestamp: &str) -> Result<DateTime<Utc>, Error> {
+    // Try ISO format first
+    if let Ok(dt) = DateTime::parse_from_rfc3339(timestamp) {
+        return Ok(dt.with_timezone(&Utc));
+    }
+
+    // Try custom format
+    let dt = NaiveDateTime::parse_from_str(timestamp, "%Y-%m-%d %H:%M:%S %z")
+        .map_err(|e| Error::Term(Box::new(e.to_string())))?;
+    
+    Ok(DateTime::from_naive_utc_and_offset(dt, Utc))
+}
+
+fn get_sport_type(sport: &str) -> (String, String) {
+    match sport {
+        "running" => ("Run".to_string(), "run".to_string()),
+        "cycling" => ("Ride".to_string(), "bike".to_string()),
+        "swimming" => ("Swim".to_string(), "swim".to_string()),
+        _ => (sport.to_string(), "other".to_string()),
+    }
+}
+
+fn get_value_by_priority(fields: &HashMap<String, String>, keys: &[&str]) -> Option<String> {
+    for key in keys {
+        if let Some(value) = fields.get(*key) {
+            return Some(value.clone());
+        }
+    }
+    None
+}
+
+fn parse_coordinates(fields: &HashMap<String, String>) -> Option<Coordinates> {
+    let lat = fields.get("position_lat")
+        .and_then(|v| v.parse::<f64>().ok())
+        .map(|v| v / 11_930_465.0);
+    
+    let lon = fields.get("position_long")
+        .and_then(|v| v.parse::<f64>().ok())
+        .map(|v| v / 11_930_465.0);
+
+    match (lat, lon) {
+        (Some(lat), Some(lon)) => Some(Coordinates { lat, lon }),
+        _ => None
+    }
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn parse_fit_file<'a>(env: Env<'a>, file_path: String) -> Result<Term<'a>, Error> {
-    println!("Parsing FIT files using Profile version: {}", fitparser::profile::VERSION);
-    
     let fp = File::open(file_path).map_err(|e| Error::Term(Box::new(e.to_string())))?;
     let mut reader = BufReader::new(fp);
     
     let records = fitparser::from_reader(&mut reader)
         .map_err(|e| Error::Term(Box::new(e.to_string())))?;
 
-    let fit_records: Vec<FitRecord> = records.into_iter().map(|record| {
-        FitRecord {
-            kind: record.kind().to_string(),
-            fields: record.fields().iter().map(|field| {
-                (field.name().to_string(), field.value().to_string())
-            }).collect(),
-        }
-    }).collect();
+    // Find session data
+    let session = records.iter()
+        .find(|record| record.kind() == MesgNum::Session)
+        .ok_or_else(|| Error::Term(Box::new("No session data found".to_string())))?;
 
-    Ok(fit_records.encode(env))
+    let session_fields: HashMap<String, String> = session.fields().iter()
+        .map(|field| (field.name().to_string(), field.value().to_string()))
+        .collect();
+
+    let start_time = parse_timestamp(&session_fields["start_time"])?;
+    
+    // Parse trackpoints
+    let trackpoints: Vec<Trackpoint> = records.iter()
+        .filter(|record| record.kind() == MesgNum::Record)
+        .map(|record| {
+            let fields: HashMap<String, String> = record.fields().iter()
+                .map(|field| (field.name().to_string(), field.value().to_string()))
+                .collect();
+
+            let timestamp = parse_timestamp(&fields["timestamp"]).unwrap_or(start_time);
+            let time = (timestamp - start_time).num_seconds();
+
+            Trackpoint {
+                altitude: get_value_by_priority(&fields, &["enhanced_altitude", "altitude"])
+                    .and_then(|v| v.parse().ok()),
+                cadence: fields.get("cadence").and_then(|v| v.parse().ok()),
+                coordinates: parse_coordinates(&fields),
+                distance: fields.get("distance").and_then(|v| v.parse().ok()),
+                heartrate: fields.get("heart_rate").and_then(|v| v.parse().ok()),
+                velocity: get_value_by_priority(&fields, &["enhanced_speed", "speed"])
+                    .and_then(|v| v.parse().ok()),
+                moving: true,
+                time,
+            }
+        })
+        .collect();
+
+    // Create a LineString from our coordinates
+    let coords: LineString<f64> = LineString::from(
+        trackpoints.iter()
+            .filter_map(|tp| tp.coordinates.as_ref())
+            .map(|coord| (coord.lon, coord.lat))
+            .collect::<Vec<(f64, f64)>>()
+    );
+
+    // Encode with precision and handle the Result
+    let polyline = encode_coordinates(coords, 5).unwrap();
+
+
+    // Parse laps
+    let laps: Vec<Lap> = records.iter()
+        .filter(|record| record.kind() == MesgNum::Lap)
+        .enumerate()
+        .map(|(i, record)| {
+            let fields: HashMap<String, String> = record.fields().iter()
+                .map(|field| (field.name().to_string(), field.value().to_string()))
+                .collect();
+
+            let start_time = parse_timestamp(&fields["start_time"]).unwrap_or(start_time);
+
+            Lap {
+                average_cadence: get_value_by_priority(&fields, &["avg_running_cadence", "avg_cadence"])
+                    .and_then(|v| v.parse().ok()),
+                average_speed: get_value_by_priority(&fields, &["enhanced_avg_speed", "avg_speed"])
+                    .and_then(|v| v.parse().ok()),
+                distance: fields.get("total_distance").and_then(|v| v.parse().ok()),
+                elapsed_time: fields.get("total_elapsed_time").and_then(|v| v.parse().ok()),
+                start_index: 0,
+                end_index: 0,
+                lap_index: i as i32,
+                max_speed: get_value_by_priority(&fields, &["enhanced_max_speed", "max_speed"])
+                    .and_then(|v| v.parse().ok()),
+                moving_time: fields.get("total_elapsed_time").and_then(|v| v.parse().ok()),
+                name: fields.get("event").cloned(),
+                split: (i + 1) as i32,
+                start_date: start_time.naive_utc().to_string(),
+                start_date_local: start_time.naive_utc().to_string(),
+                total_elevation_gain: fields.get("total_ascent").and_then(|v| v.parse().ok()),
+            }
+        })
+        .collect();
+
+    let (type_str, activity_type) = get_sport_type(&session_fields["sport"]);
+
+    let activity = Activity {
+        r#type: type_str,
+        activity_type,
+        distance: session_fields.get("total_distance").and_then(|v| v.parse().ok()),
+        duration: session_fields.get("total_elapsed_time").and_then(|v| v.parse().ok()),
+        moving_time: session_fields.get("total_elapsed_time").and_then(|v| v.parse().ok()),
+        elapsed_time: session_fields.get("total_elapsed_time").and_then(|v| v.parse().ok()),
+        start_at: start_time.to_string(),
+        start_at_local: start_time.to_string(),
+        elevation_gain: session_fields.get("total_ascent").and_then(|v| v.parse().ok()),
+        polyline,
+        trackpoints,
+        laps,
+    };
+
+    Ok(activity.encode(env))
 }
 
 rustler::init!("Elixir.Squeeze.RustFit");

--- a/native/rust_fit/src/lib.rs
+++ b/native/rust_fit/src/lib.rs
@@ -9,6 +9,10 @@ use std::io::BufReader;
 use geo_types::LineString;
 
 // TODO: Laps start_date_local
+// TODO: Fix start_date_local for activity
+// TODO: Add tests
+// TODO: Refactor to make more readable
+// TODO: Add fields like ground contact time, vertical oscillation, etc.
 
 #[derive(NifStruct)]
 #[module = "Squeeze.FitRecord.Coordinates"]

--- a/native/rust_fit/src/lib.rs
+++ b/native/rust_fit/src/lib.rs
@@ -8,10 +8,8 @@ use std::fs::File;
 use std::io::BufReader;
 use geo_types::LineString;
 
-// TODO: Trackpoints grade smooth
 // TODO: Laps start_index, end_index
 // TODO: Laps start_date_local
-// TODO: Laps total_elevation_gain
 
 #[derive(NifStruct)]
 #[module = "Squeeze.FitRecord.Coordinates"]
@@ -276,13 +274,16 @@ fn parse_fit_file<'a>(env: Env<'a>, file_path: String) -> Result<Term<'a>, Error
 
             let start_time = parse_timestamp(&fields["start_time"]).unwrap_or(start_time);
 
+
             Lap {
                 average_cadence: get_value_by_priority(&fields, &["avg_running_cadence", "avg_cadence"])
                     .and_then(|v| v.parse().ok()),
                 average_speed: get_value_by_priority(&fields, &["enhanced_avg_speed", "avg_speed"])
                     .and_then(|v| v.parse().ok()),
                 distance: fields.get("total_distance").and_then(|v| v.parse().ok()),
-                elapsed_time: fields.get("total_elapsed_time").and_then(|v| v.parse().ok()),
+                elapsed_time: fields.get("total_elapsed_time")
+                    .and_then(|v| v.parse::<f64>().ok())
+                    .map(|v| v.round() as i32),
                 start_index: 0,
                 end_index: 0,
                 lap_index: i as i32,


### PR DESCRIPTION


## Changes

- FIT parsing happening in rust instead of in elixir for faster parsing
- Need to figure out how to run tests - https://github.com/rusterlium/rustler/discussions/662
Right now it needs all erlang/BEAM to test it out

## Testing

1. Install dependencies:
```bash
cd native/rust_fit
cargo build
```

2. Launch IEx:
```bash
iex -S mix
```

3. Test with a sample FIT file:
```elixir
activity = Squeeze.RustFit.parse_fit_file("/path/to/marathon.fit")

# Verify new fields exist
activity.trackpoints |> Enum.take(1) |> IO.inspect()

# Check lap timestamps
activity.laps |> Enum.map(&(&1.start_date_local)) |> IO.inspect()

# Verify activity start time
IO.puts activity.start_at_local
```

## TODO

- [ ] Add running dynamics fields (ground contact time, vertical oscillation, etc)
- [ ] Fix start_date_local for laps
- [ ] Fix start_date_local for activity
- [ ] Add comprehensive tests
- [ ] Further code refactoring for maintainability

## Next Steps

1. Add timezone conversion logic
2. Write unit tests for new fields
3. Add documentation for new fields
4. Consider adding more running metrics
